### PR TITLE
feat: Add mock tests using httpmock

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,3 +10,36 @@ https://docs.liquid.net/docs/blockstream-amp-api-specification
 ## Documentation
 
 Please ensure that you update the documentation as you add new functionality. This includes both the code documentation (doc comments) and any relevant changes to the README or other documentation files.
+
+## Testing
+
+This crate uses a combination of live and mocked tests to ensure correctness.
+
+### Live vs. Mocked Tests
+
+For every test that interacts with the AMP API, there should be two versions:
+
+-   **A live test**, with the suffix `_live` (e.g., `test_get_changelog_live`). This test hits the actual AMP API and is intended to catch any breaking changes in the API.
+-   **A mocked test**, with the suffix `_mock` (e.g., `test_get_changelog_mock`). This test uses a mock server to simulate the API and is intended to test the client's logic in isolation.
+
+Live tests are skipped by default. To run them, you must set the `AMP_TESTS` environment variable to `live`:
+
+```bash
+AMP_TESTS=live cargo test
+```
+
+You will also need to set the `AMP_USERNAME` and `AMP_PASSWORD` environment variables with valid credentials to run the live tests.
+
+### Adding New Tests
+
+When adding a new test for an API endpoint, please add both a `_live` and a `_mock` version.
+
+1.  **Create a mock function** in `src/mocks.rs`. This function should take a `&MockServer` and set up the expected response for the endpoint you are testing.
+2.  **Create the `_mock` test** in `tests/api.rs`. This test should:
+    -   Set dummy `AMP_USERNAME` and `AMP_PASSWORD` environment variables.
+    -   Start a `MockServer`.
+    -   Call the `mock_obtain_token` function from `src/mocks.rs`.
+    -   Call your new mock function.
+    -   Create an `ApiClient` using `with_base_url`, pointing to the mock server.
+    -   Call the client method and assert the result.
+3.  **Create the `_live` test** in `tests/api.rs`. This test should be a copy of the original test, with the `_live` suffix and the check to skip the test if `AMP_TESTS` is not set to `live`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,11 +18,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "amp-rs"
 version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "httpmock",
  "once_cell",
  "reqwest",
  "secrecy",
@@ -51,6 +61,184 @@ dependencies = [
 ]
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand 2.3.0",
+ "futures-lite 2.6.1",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite 2.6.1",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca"
+dependencies = [
+ "async-lock",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite 2.6.1",
+ "parking",
+ "polling 3.10.0",
+ "rustix",
+ "slab",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-object-pool"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333c456b97c3f2d50604e8b2624253b7f787208cb72eb75e64b0ad11b221652c"
+dependencies = [
+ "async-std",
+]
+
+[[package]]
+name = "async-process"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65daa13722ad51e6ab1a1b9c01299142bc75135b337923cfa10e79bbbd669f00"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.1",
+ "futures-lite 2.6.1",
+ "rustix",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f567af260ef69e1d52c2b560ce0ea230763e6fbb9214a85d768760a920e3e3c1"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite 2.6.1",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,6 +248,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -89,6 +283,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "basic-cookies"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67bd8fd42c16bdb08688243dc5f0cc117a3ca9efeeaba3a345a18a6159ad96f7"
+dependencies = [
+ "lalrpop",
+ "lalrpop-util",
+ "regex",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,6 +321,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
 
 [[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-task",
+ "futures-io",
+ "futures-lite 2.6.1",
+ "piper",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,6 +344,12 @@ name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "castaway"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
 
 [[package]]
 name = "cc"
@@ -143,6 +382,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,6 +407,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "curl"
+version = "0.4.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79fc3b6dd0b87ba36e565715bf9a2ced221311db47bd18011676f24a6066edbc"
+dependencies = [
+ "curl-sys",
+ "libc",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "socket2 0.6.0",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.83+curl-8.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5830daf304027db10c82632a464879d46a3f7c4ba17a31592657ad16c719b483"
+dependencies = [
+ "cc",
+ "libc",
+ "libnghttp2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,6 +479,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "ena"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -195,10 +522,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.1",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fnv"
@@ -246,6 +615,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand 2.3.0",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,9 +678,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -299,6 +715,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,6 +750,12 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
@@ -356,6 +790,34 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "httpmock"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b02e044d3b4c2f94936fb05f9649efa658ca788f44eb6b87554e2033fc8ce93"
+dependencies = [
+ "assert-json-diff",
+ "async-object-pool",
+ "async-trait",
+ "base64",
+ "basic-cookies",
+ "crossbeam-utils",
+ "form_urlencoded",
+ "futures-util",
+ "hyper",
+ "isahc",
+ "lazy_static",
+ "levenshtein",
+ "log",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_regex",
+ "similar",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "hyper"
@@ -536,6 +998,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "io-uring"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,6 +1022,42 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "isahc"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "334e04b4d781f436dc315cb1e7515bd96826426345d498149e4bde36b67f8ee9"
+dependencies = [
+ "async-channel 1.9.0",
+ "castaway",
+ "crossbeam-utils",
+ "curl",
+ "curl-sys",
+ "encoding_rs",
+ "event-listener 2.5.3",
+ "futures-lite 1.13.0",
+ "http",
+ "log",
+ "mime",
+ "once_cell",
+ "polling 2.8.0",
+ "slab",
+ "sluice",
+ "tracing",
+ "tracing-futures",
+ "url",
+ "waker-fn",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -569,10 +1076,94 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+dependencies = [
+ "ascii-canvas",
+ "bit-set",
+ "ena",
+ "itertools",
+ "lalrpop-util",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "levenshtein"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
+
+[[package]]
 name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "libnghttp2-sys"
+version = "0.1.11+1.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6c24e48a7167cffa7119da39d577fa482e66c688a4aac016bee862e1a713c4"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+dependencies = [
+ "bitflags 2.9.2",
+ "libc",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -601,6 +1192,9 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "memchr"
@@ -650,6 +1244,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "num-traits"
@@ -720,6 +1320,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,6 +1353,31 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
@@ -781,10 +1412,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand 2.3.0",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "polling"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5bd19146350fe804f7cb2669c851c03d69da628803dab0d98018142aaa5d829"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "potential_utf"
@@ -803,6 +1475,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
@@ -866,6 +1544,46 @@ checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.2",
 ]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
@@ -948,6 +1666,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,6 +1755,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,10 +1792,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
+name = "sluice"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7400c0eff44aa2fcb5e31a5f24ba9716ed90138769e4977a2ba6014ae63eb5"
+dependencies = [
+ "async-channel 1.9.0",
+ "futures-core",
+ "futures-io",
+]
 
 [[package]]
 name = "smallvec"
@@ -1091,6 +1851,18 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
 
 [[package]]
 name = "syn"
@@ -1147,11 +1919,22 @@ version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
- "fastrand",
+ "fastrand 2.3.0",
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
 ]
 
 [[package]]
@@ -1172,6 +1955,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -1261,6 +2053,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1287,6 +2080,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1297,6 +2100,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "url"
@@ -1316,10 +2125,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "value-bag"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "waker-fn"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -1425,6 +2256,37 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,10 @@ tracing = "0.1"
 tokio-retry = "0.3.0"
 secrecy = { version = "0.8", features = ["serde"] }
 url = "2.2.2"
+httpmock = { version = "0.6.8", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
+
+[features]
+mocks = ["httpmock"]

--- a/README.md
+++ b/README.md
@@ -5,3 +5,45 @@ A Rust client for the Blockstream AMP API.
 ## Usage
 
 See the examples directory for usage.
+
+## Testing with Mocks
+
+This client provides a public `mocks` module that can be used by downstream applications for testing purposes. The mocks are built using `httpmock` and allow you to test your application's integration with the AMP API without making live network calls.
+
+To use the mocks in your tests, you will need to:
+
+1.  Add `amp-rs` and `httpmock` to your `[dev-dependencies]` in `Cargo.toml`.
+2.  In your test, start a `MockServer` from `httpmock`.
+3.  Use the functions in the `amp_rs::mocks` module to set up the desired mock responses on the server.
+4.  Instantiate the `ApiClient` using `ApiClient::with_base_url`, passing it the URL of the mock server.
+
+### Example
+
+```rust
+#[cfg(test)]
+mod tests {
+    use amp_rs::{mocks, ApiClient};
+    use httpmock::prelude::*;
+    use url::Url;
+
+    #[tokio::test]
+    async fn my_app_test() {
+        // Arrange
+        std::env::set_var("AMP_USERNAME", "mock_user");
+        std::env::set_var("AMP_PASSWORD", "mock_pass");
+        let server = MockServer::start();
+
+        mocks::mock_obtain_token(&server);
+        mocks::mock_get_assets(&server);
+
+        let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+
+        // Act
+        let assets = client.get_assets().await;
+
+        // Assert
+        assert!(assets.is_ok());
+        assert!(!assets.unwrap().is_empty());
+    }
+}
+```

--- a/src/client.rs
+++ b/src/client.rs
@@ -41,11 +41,15 @@ pub struct ApiClient {
 impl ApiClient {
     pub fn new() -> Result<Self, Error> {
         let base_url = get_amp_api_base_url()?;
-        let client = Client::builder()
-            .user_agent("amp-rs-client/0.1.0")
-            .build()?;
         Ok(ApiClient {
-            client,
+            client: Client::new(),
+            base_url,
+        })
+    }
+
+    pub fn with_base_url(base_url: Url) -> Result<Self, Error> {
+        Ok(ApiClient {
+            client: Client::new(),
             base_url,
         })
     }
@@ -74,7 +78,7 @@ impl ApiClient {
 
         // Make POST request to obtain token
         let mut url = self.base_url.clone();
-        url.path_segments_mut().unwrap().push("user/obtain_token");
+        url.path_segments_mut().unwrap().push("user").push("obtain_token");
 
         let response = self.client
             .post(url)
@@ -167,7 +171,7 @@ impl ApiClient {
         let token = self.get_token().await?;
 
         let mut url = self.base_url.clone();
-        url.path_segments_mut().unwrap().push("assets/");
+        url.path_segments_mut().unwrap().push("assets");
 
         let response = self.client
             .get(url)
@@ -293,7 +297,7 @@ impl ApiClient {
         let token = self.get_token().await?;
 
         let mut url = self.base_url.clone();
-        url.path_segments_mut().unwrap().push("registered_users/");
+        url.path_segments_mut().unwrap().push("registered_users");
 
         let response = self.client
             .get(url)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod client;
 pub mod model;
+#[cfg(feature = "mocks")]
+pub mod mocks;
 
 pub use client::{ApiClient, Error};

--- a/src/mocks.rs
+++ b/src/mocks.rs
@@ -1,0 +1,290 @@
+use httpmock::prelude::*;
+use serde_json::json;
+
+pub fn mock_get_changelog(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(GET)
+            .path("/changelog");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "0.1.0": {
+                    "added": [
+                        "Initial release"
+                    ]
+                }
+            }));
+    });
+}
+
+pub fn mock_get_managers(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(GET)
+            .path("/managers");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!([{
+                "id": 1,
+                "username": "mock_manager",
+                "is_locked": false,
+                "assets": []
+            }]));
+    });
+}
+
+pub fn mock_create_manager(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(POST)
+            .path("/managers/create");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "id": 2,
+                "username": "test_manager",
+                "is_locked": false,
+                "assets": []
+            }));
+    });
+}
+
+pub fn mock_obtain_token(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(POST)
+            .path("/user/obtain_token")
+            .header("content-type", "application/json");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "token": "mock_token"
+            }));
+    });
+}
+
+pub fn mock_get_gaid_address(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(GET)
+            .path("/gaids/GAbYScu6jkWUND2jo3L4KJxyvo55d/address");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "address": "mock_address"
+            }));
+    });
+}
+
+pub fn mock_validate_gaid(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(GET)
+            .path("/gaids/GAbYScu6jkWUND2jo3L4KJxyvo55d/validate");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "is_valid": true
+            }));
+    });
+}
+
+pub fn mock_get_categories(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(GET)
+            .path("/categories");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!([{
+                "id": 1,
+                "name": "Mock Category",
+                "description": "A mock category",
+                "registered_users": [],
+                "assets": []
+            }]));
+    });
+}
+
+pub fn mock_add_category(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(POST)
+            .path("/categories/add");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "id": 2,
+                "name": "Test Category",
+                "description": "Test category description",
+                "registered_users": [],
+                "assets": []
+            }));
+    });
+}
+
+pub fn mock_add_registered_user(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(POST)
+            .path("/registered_users/add");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "id": 2,
+                "name": "Test User",
+                "gaid": null,
+                "is_company": false,
+                "authorization_url": "https://example.com/auth_new",
+                "categories": [],
+                "creator": 1
+            }));
+    });
+}
+
+pub fn mock_delete_asset(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(DELETE)
+            .path("/assets/new_mock_asset_uuid/delete");
+        then.status(200);
+    });
+}
+
+pub fn mock_get_registered_users(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(GET)
+            .path("/registered_users");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!([{
+                "id": 1,
+                "name": "Mock User",
+                "gaid": "mock_gaid",
+                "is_company": false,
+                "authorization_url": "https://example.com/auth",
+                "categories": [],
+                "creator": 1
+            }]));
+    });
+}
+
+pub fn mock_get_registered_user(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(GET)
+            .path("/registered_users/1");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "id": 1,
+                "name": "Mock User",
+                "gaid": "mock_gaid",
+                "is_company": false,
+                "authorization_url": "https://example.com/auth",
+                "categories": [],
+                "creator": 1
+            }));
+    });
+}
+
+pub fn mock_edit_asset(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(PUT)
+            .path("/assets/mock_asset_uuid/edit")
+            .header("content-type", "application/json");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "name": "Mock Asset",
+                "asset_uuid": "mock_asset_uuid",
+                "issuer": 1,
+                "asset_id": "mock_asset_id",
+                "reissuance_token_id": null,
+                "requirements": [],
+                "ticker": "MOCK",
+                "precision": 8,
+                "domain": "mock.com",
+                "pubkey": "mock_pubkey",
+                "is_registered": true,
+                "is_authorized": true,
+                "is_locked": false,
+                "issuer_authorization_endpoint": "https://example.com/authorize",
+                "transfer_restricted": true
+            }));
+    });
+}
+
+pub fn mock_issue_asset(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(POST)
+            .path("/assets/issue");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "name": "Test Asset",
+                "amount": 1000,
+                "destination_address": "destination_address",
+                "domain": "example.com",
+                "ticker": "TSTA",
+                "pubkey": "03...",
+                "is_confidential": true,
+                "is_reissuable": false,
+                "reissuance_amount": 0,
+                "reissuance_address": "reissuance_address",
+                "asset_id": "mock_asset_id",
+                "reissuance_token_id": null,
+                "asset_uuid": "new_mock_asset_uuid",
+                "txid": "mock_txid",
+                "vin": 0,
+                "asset_vout": 0,
+                "reissuance_vout": null,
+                "issuer_authorization_endpoint": null,
+                "transfer_restricted": true,
+                "issuance_assetblinder": "mock_blinder",
+                "issuance_tokenblinder": null
+            }));
+    });
+}
+
+pub fn mock_get_assets(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(GET)
+            .path("/assets");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!([{
+                "name": "Mock Asset",
+                "asset_uuid": "mock_asset_uuid",
+                "issuer": 1,
+                "asset_id": "mock_asset_id",
+                "reissuance_token_id": null,
+                "requirements": [],
+                "ticker": "MOCK",
+                "precision": 8,
+                "domain": "mock.com",
+                "pubkey": "mock_pubkey",
+                "is_registered": true,
+                "is_authorized": true,
+                "is_locked": false,
+                "issuer_authorization_endpoint": null,
+                "transfer_restricted": true
+            }]));
+    });
+}
+
+pub fn mock_get_asset(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(GET)
+            .path("/assets/mock_asset_uuid");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "name": "Mock Asset",
+                "asset_uuid": "mock_asset_uuid",
+                "issuer": 1,
+                "asset_id": "mock_asset_id",
+                "reissuance_token_id": null,
+                "requirements": [],
+                "ticker": "MOCK",
+                "precision": 8,
+                "domain": "mock.com",
+                "pubkey": "mock_pubkey",
+                "is_registered": true,
+                "is_authorized": true,
+                "is_locked": false,
+                "issuer_authorization_endpoint": "https://example.com/authorize",
+                "transfer_restricted": true
+            }));
+    });
+}

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -1,8 +1,16 @@
 use amp_rs::ApiClient;
 use std::env;
+use httpmock::prelude::*;
+use url::Url;
+use amp_rs::mocks;
 
 #[tokio::test]
-async fn test_get_changelog() {
+async fn test_get_changelog_live() {
+    if env::var("AMP_TESTS").unwrap_or_default() != "live" {
+        println!("Skipping live test");
+        return;
+    }
+
     // Ensure that the environment variables are set
     if env::var("AMP_USERNAME").is_err() || env::var("AMP_PASSWORD").is_err() {
         panic!("AMP_USERNAME and AMP_PASSWORD must be set for this test");
@@ -17,7 +25,28 @@ async fn test_get_changelog() {
 }
 
 #[tokio::test]
-async fn test_get_assets() {
+async fn test_get_changelog_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_get_changelog(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let changelog = client.get_changelog().await;
+
+    assert!(changelog.is_ok());
+    let changelog_val = changelog.unwrap();
+    assert!(changelog_val.as_object().unwrap().len() > 0);
+}
+
+#[tokio::test]
+async fn test_get_assets_live() {
+    if env::var("AMP_TESTS").unwrap_or_default() != "live" {
+        println!("Skipping live test");
+        return;
+    }
+
     // Ensure that the environment variables are set
     if env::var("AMP_USERNAME").is_err() || env::var("AMP_PASSWORD").is_err() {
         panic!("AMP_USERNAME and AMP_PASSWORD must be set for this test");
@@ -30,7 +59,27 @@ async fn test_get_assets() {
 }
 
 #[tokio::test]
-async fn test_get_asset() {
+async fn test_get_assets_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_get_assets(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let assets = client.get_assets().await;
+
+    assert!(assets.is_ok());
+    assert!(!assets.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn test_get_asset_live() {
+    if env::var("AMP_TESTS").unwrap_or_default() != "live" {
+        println!("Skipping live test");
+        return;
+    }
+
     // Ensure that the environment variables are set
     if env::var("AMP_USERNAME").is_err() || env::var("AMP_PASSWORD").is_err() {
         panic!("AMP_USERNAME and AMP_PASSWORD must be set for this test");
@@ -48,8 +97,33 @@ async fn test_get_asset() {
 }
 
 #[tokio::test]
+async fn test_get_asset_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_get_assets(&server);
+    mocks::mock_get_asset(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let assets = client.get_assets().await.unwrap();
+
+    if let Some(asset_to_test) = assets.first() {
+        let asset = client.get_asset(&asset_to_test.asset_uuid).await;
+        assert!(asset.is_ok());
+        assert_eq!(asset.unwrap().asset_uuid, "mock_asset_uuid");
+    } else {
+        panic!("mock_get_assets should have returned at least one asset");
+    }
+}
+
+#[tokio::test]
 #[ignore]
-async fn test_issue_asset() {
+async fn test_issue_asset_live() {
+    if env::var("AMP_TESTS").unwrap_or_default() != "live" {
+        println!("Skipping live test");
+        return;
+    }
     // This test is ignored by default because it performs a state-changing operation
     // and requires a valid destination address.
     // To run this test:
@@ -85,8 +159,42 @@ async fn test_issue_asset() {
 }
 
 #[tokio::test]
+async fn test_issue_asset_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_issue_asset(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let issuance_request = amp_rs::model::IssuanceRequest {
+        name: "Test Asset".to_string(),
+        amount: 1000,
+        destination_address: "destination_address".to_string(),
+        domain: "example.com".to_string(),
+        ticker: "TSTA".to_string(),
+        pubkey: "03...".to_string(), // Replace with a valid pubkey
+        precision: Some(8),
+        is_confidential: Some(true),
+        is_reissuable: Some(false),
+        reissuance_amount: None,
+        reissuance_address: None,
+        transfer_restricted: Some(true),
+    };
+
+    let result = client.issue_asset(&issuance_request).await;
+    assert!(result.is_ok());
+    let response = result.unwrap();
+    assert_eq!(response.asset_uuid, "new_mock_asset_uuid");
+}
+
+#[tokio::test]
 #[ignore]
-async fn test_edit_asset() {
+async fn test_edit_asset_live() {
+    if env::var("AMP_TESTS").unwrap_or_default() != "live" {
+        println!("Skipping live test");
+        return;
+    }
     // This test is ignored by default because it performs a state-changing operation.
     // To run this test:
     // 1. Set the `AMP_USERNAME` and `AMP_PASSWORD` environment variables.
@@ -112,8 +220,40 @@ async fn test_edit_asset() {
 }
 
 #[tokio::test]
+async fn test_edit_asset_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_get_assets(&server);
+    mocks::mock_edit_asset(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let assets = client.get_assets().await.unwrap();
+
+    if let Some(asset_to_edit) = assets.first() {
+        let edit_request = amp_rs::model::EditAssetRequest {
+            issuer_authorization_endpoint: "https://example.com/authorize".to_string(),
+        };
+        let result = client.edit_asset(&asset_to_edit.asset_uuid, &edit_request).await;
+        if let Err(e) = &result {
+            println!("Error: {:?}", e);
+        }
+        assert!(result.is_ok());
+        let edited_asset = result.unwrap();
+        assert_eq!(edited_asset.issuer_authorization_endpoint, Some("https://example.com/authorize".to_string()));
+    } else {
+        panic!("mock_get_assets should have returned at least one asset");
+    }
+}
+
+#[tokio::test]
 #[ignore]
-async fn test_delete_asset() {
+async fn test_delete_asset_live() {
+    if env::var("AMP_TESTS").unwrap_or_default() != "live" {
+        println!("Skipping live test");
+        return;
+    }
     // This test is ignored by default because it performs a state-changing operation.
     // To run this test:
     // 1. Set the `AMP_USERNAME` and `AMP_PASSWORD` environment variables.
@@ -149,7 +289,42 @@ async fn test_delete_asset() {
 }
 
 #[tokio::test]
-async fn test_get_registered_users() {
+async fn test_delete_asset_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_issue_asset(&server);
+    mocks::mock_delete_asset(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let issuance_request = amp_rs::model::IssuanceRequest {
+        name: "Test Asset to Delete".to_string(),
+        amount: 1000,
+        destination_address: "destination_address".to_string(),
+        domain: "example.com".to_string(),
+        ticker: "TSTD".to_string(),
+        pubkey: "03...".to_string(), // Replace with a valid pubkey
+        precision: Some(8),
+        is_confidential: Some(true),
+        is_reissuable: Some(false),
+        reissuance_amount: None,
+        reissuance_address: None,
+        transfer_restricted: Some(true),
+    };
+
+    let issue_result = client.issue_asset(&issuance_request).await.unwrap();
+    let delete_result = client.delete_asset(&issue_result.asset_uuid).await;
+    assert!(delete_result.is_ok());
+}
+
+#[tokio::test]
+async fn test_get_registered_users_live() {
+    if env::var("AMP_TESTS").unwrap_or_default() != "live" {
+        println!("Skipping live test");
+        return;
+    }
+
     // Ensure that the environment variables are set
     if env::var("AMP_USERNAME").is_err() || env::var("AMP_PASSWORD").is_err() {
         panic!("AMP_USERNAME and AMP_PASSWORD must be set for this test");
@@ -162,7 +337,27 @@ async fn test_get_registered_users() {
 }
 
 #[tokio::test]
-async fn test_get_registered_user() {
+async fn test_get_registered_users_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_get_registered_users(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let registered_users = client.get_registered_users().await;
+
+    assert!(registered_users.is_ok());
+    assert!(!registered_users.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn test_get_registered_user_live() {
+    if env::var("AMP_TESTS").unwrap_or_default() != "live" {
+        println!("Skipping live test");
+        return;
+    }
+
     // Ensure that the environment variables are set
     if env::var("AMP_USERNAME").is_err() || env::var("AMP_PASSWORD").is_err() {
         panic!("AMP_USERNAME and AMP_PASSWORD must be set for this test");
@@ -180,8 +375,33 @@ async fn test_get_registered_user() {
 }
 
 #[tokio::test]
+async fn test_get_registered_user_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_get_registered_users(&server);
+    mocks::mock_get_registered_user(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let registered_users = client.get_registered_users().await.unwrap();
+
+    if let Some(user_to_test) = registered_users.first() {
+        let user = client.get_registered_user(user_to_test.id).await;
+        assert!(user.is_ok());
+        assert_eq!(user.unwrap().id, 1);
+    } else {
+        panic!("mock_get_registered_users should have returned at least one user");
+    }
+}
+
+#[tokio::test]
 #[ignore]
-async fn test_add_registered_user() {
+async fn test_add_registered_user_live() {
+    if env::var("AMP_TESTS").unwrap_or_default() != "live" {
+        println!("Skipping live test");
+        return;
+    }
     // This test is ignored by default because it performs a state-changing operation.
     // To run this test:
     // 1. Set the `AMP_USERNAME` and `AMP_PASSWORD` environment variables.
@@ -203,7 +423,34 @@ async fn test_add_registered_user() {
 }
 
 #[tokio::test]
-async fn test_get_categories() {
+async fn test_add_registered_user_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_add_registered_user(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let new_user = amp_rs::model::RegisteredUserAdd {
+        name: "Test User".to_string(),
+        gaid: None,
+        is_company: false,
+    };
+
+    let result = client.add_registered_user(&new_user).await;
+    assert!(result.is_ok());
+    let added_user = result.unwrap();
+    assert_eq!(added_user.id, 2);
+    assert_eq!(added_user.name, "Test User");
+}
+
+#[tokio::test]
+async fn test_get_categories_live() {
+    if env::var("AMP_TESTS").unwrap_or_default() != "live" {
+        println!("Skipping live test");
+        return;
+    }
+
     // Ensure that the environment variables are set
     if env::var("AMP_USERNAME").is_err() || env::var("AMP_PASSWORD").is_err() {
         panic!("AMP_USERNAME and AMP_PASSWORD must be set for this test");
@@ -216,8 +463,27 @@ async fn test_get_categories() {
 }
 
 #[tokio::test]
+async fn test_get_categories_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_get_categories(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let categories = client.get_categories().await;
+
+    assert!(categories.is_ok());
+    assert!(!categories.unwrap().is_empty());
+}
+
+#[tokio::test]
 #[ignore]
-async fn test_add_category() {
+async fn test_add_category_live() {
+    if env::var("AMP_TESTS").unwrap_or_default() != "live" {
+        println!("Skipping live test");
+        return;
+    }
     // This test is ignored by default because it performs a state-changing operation.
     // To run this test:
     // 1. Set the `AMP_USERNAME` and `AMP_PASSWORD` environment variables.
@@ -238,7 +504,33 @@ async fn test_add_category() {
 }
 
 #[tokio::test]
-async fn test_validate_gaid() {
+async fn test_add_category_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_add_category(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let new_category = amp_rs::model::CategoryAdd {
+        name: "Test Category".to_string(),
+        description: Some("Test category description".to_string()),
+    };
+
+    let result = client.add_category(&new_category).await;
+    assert!(result.is_ok());
+    let added_category = result.unwrap();
+    assert_eq!(added_category.id, 2);
+    assert_eq!(added_category.name, "Test Category");
+}
+
+#[tokio::test]
+async fn test_validate_gaid_live() {
+    if env::var("AMP_TESTS").unwrap_or_default() != "live" {
+        println!("Skipping live test");
+        return;
+    }
+
     // Ensure that the environment variables are set
     if env::var("AMP_USERNAME").is_err() || env::var("AMP_PASSWORD").is_err() {
         panic!("AMP_USERNAME and AMP_PASSWORD must be set for this test");
@@ -253,7 +545,28 @@ async fn test_validate_gaid() {
 }
 
 #[tokio::test]
-async fn test_get_gaid_address() {
+async fn test_validate_gaid_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_validate_gaid(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let gaid = "GAbYScu6jkWUND2jo3L4KJxyvo55d";
+    let result = client.validate_gaid(gaid).await;
+    assert!(result.is_ok());
+    let response = result.unwrap();
+    assert!(response.is_valid);
+}
+
+#[tokio::test]
+async fn test_get_gaid_address_live() {
+    if env::var("AMP_TESTS").unwrap_or_default() != "live" {
+        println!("Skipping live test");
+        return;
+    }
+
     // Ensure that the environment variables are set
     if env::var("AMP_USERNAME").is_err() || env::var("AMP_PASSWORD").is_err() {
         panic!("AMP_USERNAME and AMP_PASSWORD must be set for this test");
@@ -268,7 +581,29 @@ async fn test_get_gaid_address() {
 }
 
 #[tokio::test]
-async fn test_get_managers() {
+async fn test_get_gaid_address_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_get_gaid_address(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let gaid = "GAbYScu6jkWUND2jo3L4KJxyvo55d";
+    let result = client.get_gaid_address(gaid).await;
+    assert!(result.is_ok());
+    let response = result.unwrap();
+    assert!(!response.address.is_empty());
+    assert_eq!(response.address, "mock_address");
+}
+
+#[tokio::test]
+async fn test_get_managers_live() {
+    if env::var("AMP_TESTS").unwrap_or_default() != "live" {
+        println!("Skipping live test");
+        return;
+    }
+
     // Ensure that the environment variables are set
     if env::var("AMP_USERNAME").is_err() || env::var("AMP_PASSWORD").is_err() {
         panic!("AMP_USERNAME and AMP_PASSWORD must be set for this test");
@@ -281,8 +616,27 @@ async fn test_get_managers() {
 }
 
 #[tokio::test]
+async fn test_get_managers_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_get_managers(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let managers = client.get_managers().await;
+
+    assert!(managers.is_ok());
+    assert!(!managers.unwrap().is_empty());
+}
+
+#[tokio::test]
 #[ignore]
-async fn test_create_manager() {
+async fn test_create_manager_live() {
+    if env::var("AMP_TESTS").unwrap_or_default() != "live" {
+        println!("Skipping live test");
+        return;
+    }
     // This test is ignored by default because it performs a state-changing operation.
     // To run this test:
     // 1. Set the `AMP_USERNAME` and `AMP_PASSWORD` environment variables.
@@ -300,4 +654,25 @@ async fn test_create_manager() {
 
     let result = client.create_manager(&new_manager).await;
     assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_create_manager_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_create_manager(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let new_manager = amp_rs::model::ManagerCreate {
+        username: "test_manager".to_string(),
+        password: "password".to_string(),
+    };
+
+    let result = client.create_manager(&new_manager).await;
+    assert!(result.is_ok());
+    let created_manager = result.unwrap();
+    assert_eq!(created_manager.id, 2);
+    assert_eq!(created_manager.username, "test_manager");
 }


### PR DESCRIPTION
This change introduces a testing framework with mocks for the API client using `httpmock`.

- Refactors existing tests into `_live` and `_mock` versions.
- Live tests are skipped by default and can be enabled with `AMP_TESTS=live`.
- Adds a public `mocks` module for downstream testing.
- Updates `CONTRIBUTING.md` and `README.md` with instructions.