### PR TITLE
feat: Implement full AMP client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,7 @@ dependencies = [
  "tokio-retry",
  "tracing",
  "url",
+ "zeroize",
 ]
 
 [[package]]
@@ -2664,6 +2665,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tracing = "0.1"
 tokio-retry = "0.3.0"
 secrecy = { version = "0.8", features = ["serde"] }
 url = "2.2.2"
+zeroize = { version = "1.5", features = ["derive"] }
 httpmock = { version = "0.6.8", optional = true }
 
 [dev-dependencies]

--- a/src/mocks.rs
+++ b/src/mocks.rs
@@ -17,6 +17,270 @@ pub fn mock_get_changelog(server: &MockServer) {
     });
 }
 
+pub fn mock_list_audits(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(GET)
+            .path("/audits");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!([{
+                "id": 1,
+                "asset": "mock_asset_uuid",
+                "audit_type": "test_audit",
+                "audit_status": "pending",
+                "created": "2021-01-01T00:00:00Z",
+                "updated": "2021-01-01T00:00:00Z",
+                "blockheight": null
+            }]));
+    });
+}
+
+pub fn mock_create_audit(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(POST)
+            .path("/audits");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "id": 2,
+                "asset": "mock_asset_uuid",
+                "audit_type": "test_audit",
+                "audit_status": "pending",
+                "created": "2021-01-01T00:00:00Z",
+                "updated": "2021-01-01T00:00:00Z",
+                "blockheight": null
+            }));
+    });
+}
+
+pub fn mock_get_audit(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(GET)
+            .path("/audits/1");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "id": 1,
+                "asset": "mock_asset_uuid",
+                "audit_type": "test_audit",
+                "audit_status": "pending",
+                "created": "2021-01-01T00:00:00Z",
+                "updated": "2021-01-01T00:00:00Z",
+                "blockheight": null
+            }));
+    });
+}
+
+pub fn mock_update_audit(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(PUT)
+            .path("/audits/1");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "id": 1,
+                "asset": "mock_asset_uuid",
+                "audit_type": "test_audit",
+                "audit_status": "completed",
+                "created": "2021-01-01T00:00:00Z",
+                "updated": "2021-01-01T00:00:00Z",
+                "blockheight": null
+            }));
+    });
+}
+
+pub fn mock_delete_audit(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(DELETE)
+            .path("/audits/1");
+        then.status(200);
+    });
+}
+
+pub fn mock_broadcast_transaction(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(POST)
+            .path("/tx/broadcast");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "txid": "mock_txid",
+                "hex": "mock_tx_hex"
+            }));
+    });
+}
+
+pub fn mock_get_broadcast_status(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(GET)
+            .path("/tx/broadcast/mock_txid");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "txid": "mock_txid",
+                "hex": "mock_tx_hex"
+            }));
+    });
+}
+
+pub fn mock_list_asset_permissions(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(GET)
+            .path("/asset_permissions");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!([{
+                "id": 1,
+                "manager": 1,
+                "asset": "mock_asset_uuid",
+                "asset_group": null,
+                "permission": "view"
+            }]));
+    });
+}
+
+pub fn mock_create_asset_permission(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(POST)
+            .path("/asset_permissions");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "id": 2,
+                "manager": 1,
+                "asset": "mock_asset_uuid",
+                "asset_group": null,
+                "permission": "view"
+            }));
+    });
+}
+
+pub fn mock_get_asset_permission(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(GET)
+            .path("/asset_permissions/1");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "id": 1,
+                "manager": 1,
+                "asset": "mock_asset_uuid",
+                "asset_group": null,
+                "permission": "view"
+            }));
+    });
+}
+
+pub fn mock_update_asset_permission(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(PUT)
+            .path("/asset_permissions/1");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "id": 1,
+                "manager": 1,
+                "asset": "mock_asset_uuid",
+                "asset_group": null,
+                "permission": "transfer"
+            }));
+    });
+}
+
+pub fn mock_delete_asset_permission(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(DELETE)
+            .path("/asset_permissions/1");
+        then.status(200);
+    });
+}
+
+pub fn mock_list_asset_groups(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(GET)
+            .path("/asset_groups");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!([{
+                "id": 1,
+                "name": "Mock Asset Group",
+                "assets": []
+            }]));
+    });
+}
+
+pub fn mock_create_asset_group(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(POST)
+            .path("/asset_groups");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "id": 2,
+                "name": "test_group",
+                "assets": []
+            }));
+    });
+}
+
+pub fn mock_get_asset_group(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(GET)
+            .path("/asset_groups/1");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "id": 1,
+                "name": "Mock Asset Group",
+                "assets": []
+            }));
+    });
+}
+
+pub fn mock_update_asset_group(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(PUT)
+            .path("/asset_groups/1");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "id": 1,
+                "name": "updated_group_name",
+                "assets": []
+            }));
+    });
+}
+
+pub fn mock_delete_asset_group(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(DELETE)
+            .path("/asset_groups/1");
+        then.status(200);
+    });
+}
+
+pub fn mock_add_asset_to_group(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(POST)
+            .path("/asset_groups/1/assets");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "id": 1,
+                "name": "Mock Asset Group",
+                "assets": ["mock_asset_uuid"]
+            }));
+    });
+}
+
+pub fn mock_remove_asset_from_group(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(DELETE)
+            .path("/asset_groups/1/assets/mock_asset_uuid");
+        then.status(200);
+    });
+}
+
 pub fn mock_get_managers(server: &MockServer) {
     server.mock(|when, then| {
         when.method(GET)

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,4 +1,6 @@
+use secrecy::{DebugSecret, Secret, SerializableSecret};
 use serde::{Deserialize, Serialize};
+use zeroize::Zeroize;
 
 /// Request payload for AMP token acquisition
 #[derive(Debug, Serialize)]
@@ -11,6 +13,37 @@ pub struct TokenRequest {
 #[derive(Debug, Deserialize)]
 pub struct TokenResponse {
     pub token: String,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Password(pub String);
+
+impl Zeroize for Password {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+impl From<String> for Password {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl SerializableSecret for Password {}
+
+impl DebugSecret for Password {}
+
+#[derive(Debug, Serialize)]
+pub struct ChangePasswordRequest {
+    pub password: Secret<Password>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ChangePasswordResponse {
+    pub username: String,
+    pub password: Secret<Password>,
+    pub token: Secret<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -103,6 +136,11 @@ pub struct RegisteredUserAdd {
     pub is_company: bool,
 }
 
+#[derive(Debug, Serialize)]
+pub struct RegisteredUserEdit {
+    pub name: String,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct CategoryResponse {
     pub id: i64,
@@ -115,6 +153,12 @@ pub struct CategoryResponse {
 #[derive(Debug, Serialize)]
 pub struct CategoryAdd {
     pub name: String,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CategoryEdit {
+    pub name: Option<String>,
     pub description: Option<String>,
 }
 
@@ -142,4 +186,287 @@ pub struct Manager {
 pub struct ManagerCreate {
     pub username: String,
     pub password: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum Status {
+    Unconfirmed,
+    Confirmed,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DistributionAssignment {
+    pub registered_user: i64,
+    pub amount: i64,
+    pub vout: i64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Transaction {
+    pub txid: String,
+    pub transaction_status: Status,
+    pub included_blockheight: i64,
+    pub confirmed_datetime: String,
+    pub assignments: Vec<DistributionAssignment>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Distribution {
+    pub distribution_uuid: String,
+    pub distribution_status: Status,
+    pub transactions: Vec<Transaction>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Assignment {
+    pub id: i64,
+    pub registered_user: i64,
+    pub amount: i64,
+    pub receiving_address: String,
+    pub distribution_uuid: Option<String>,
+    pub ready_for_distribution: bool,
+    pub vesting_datetime: Option<String>,
+    pub vesting_timestamp: Option<i64>,
+    pub has_vested: bool,
+    pub is_distributed: bool,
+    pub creator: i64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct RegisteredUserSummary {
+    pub asset_uuid: String,
+    pub asset_id: String,
+    pub assignments: Vec<Assignment>,
+    pub assignments_sum: i64,
+    pub distributions: Vec<Distribution>,
+    pub distributions_sum: i64,
+    pub balance: i64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Activity {
+    #[serde(rename = "type")]
+    pub activity_type: String,
+    pub datetime: String,
+    pub description: String,
+    pub txid: String,
+    pub vout: i64,
+    pub blockheight: i64,
+    pub asset_blinder: String,
+    pub amount_blinder: String,
+    #[serde(rename = "registered user")]
+    pub registered_user: Option<i64>,
+    pub amount: i64,
+}
+
+#[derive(Debug, Serialize, Default)]
+pub struct AssetActivityParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub count: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sortcolumn: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sortorder: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub height_start: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub height_stop: Option<i64>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Ownership {
+    pub owner: String,
+    pub amount: i64,
+    #[serde(rename = "GAID")]
+    pub gaid: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Outpoint {
+    pub txid: String,
+    pub vout: i64,
+}
+
+pub type LostOutputs = Vec<Outpoint>;
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Balance {
+    pub confirmed_balance: Vec<Ownership>,
+    pub lost_outputs: LostOutputs,
+    pub reissuance_lost_outputs: LostOutputs,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct AssetLostOutputs {
+    pub lost_outputs: LostOutputs,
+    pub reissuance_lost_outputs: LostOutputs,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct AssetSummary {
+    pub asset_id: String,
+    pub reissuance_token_id: Option<String>,
+    pub issued: i64,
+    pub reissued: i64,
+    pub assigned: i64,
+    pub distributed: i64,
+    pub burned: i64,
+    pub blacklisted: i64,
+    pub registered_users: i64,
+    pub active_registered_users: i64,
+    pub active_green_subaccounts: i64,
+    #[serde(rename = "reissuance_tokens")]
+    pub reissuance_tokens: i64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Utxo {
+    pub txid: String,
+    pub vout: i64,
+    pub asset: String,
+    pub amount: i64,
+    pub registered_user: Option<i64>,
+    pub gaid: Option<String>,
+    pub blacklisted: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Reissuance {
+    pub txid: String,
+    pub vout: i64,
+    pub destination_address: String,
+    pub reissuance_amount: i64,
+    pub confirmed_in_block: String,
+    pub created: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ReissueRequest {
+    pub amount_to_reissue: i64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ReissueConfirmRequest {
+    pub details: serde_json::Value,
+    pub listissuances: Vec<serde_json::Value>,
+    pub reissuance_output: serde_json::Value,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BurnRequest {
+    pub amount: i64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct BurnCreate {
+    pub command: String,
+    pub min_supported_client_script_version: i64,
+    pub base_url: String,
+    pub asset_uuid: String,
+    pub asset_id: String,
+    pub amount: f64,
+    pub utxos: Vec<Outpoint>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BurnConfirmRequest {
+    pub tx_data: serde_json::Value,
+    pub change_data: Vec<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct AssetGroup {
+    pub id: i64,
+    pub name: String,
+    pub assets: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CreateAssetGroup {
+    pub name: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct UpdateAssetGroup {
+    pub name: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AddAssetToGroup {
+    pub asset_uuid: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Permission {
+    View,
+    Receive,
+    Transfer,
+    Assign,
+    Distribute,
+    Reissue,
+    Burn,
+    Acquire,
+    Manage,
+    Permissions,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct AssetPermission {
+    pub id: i64,
+    pub manager: i64,
+    pub asset: Option<String>,
+    pub asset_group: Option<i64>,
+    pub permission: Permission,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Audit {
+    pub id: i64,
+    pub asset: String,
+    pub audit_type: String,
+    pub audit_status: String,
+    pub created: String,
+    pub updated: String,
+    pub blockheight: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CreateAudit {
+    pub asset_uuid: String,
+    pub audit_type: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct UpdateAudit {
+    pub audit_status: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct BroadcastResponse {
+    pub txid: String,
+    pub hex: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CreateAssetPermission {
+    pub manager: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub asset: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub asset_group: Option<i64>,
+    pub permission: Permission,
+}
+
+#[derive(Debug, Serialize)]
+pub struct UpdateAssetPermission {
+    pub manager: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub asset: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub asset_group: Option<i64>,
+    pub permission: Permission,
 }

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -676,3 +676,491 @@ async fn test_create_manager_mock() {
     assert_eq!(created_manager.id, 2);
     assert_eq!(created_manager.username, "test_manager");
 }
+
+#[tokio::test]
+async fn test_list_asset_groups_live() {
+    if env::var("AMP_TESTS").unwrap_or_default() != "live" {
+        println!("Skipping live test");
+        return;
+    }
+    let client = ApiClient::new().unwrap();
+    let result = client.list_asset_groups().await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_create_and_delete_asset_group_live() {
+    if env::var("AMP_TESTS").unwrap_or_default() != "live" {
+        println!("Skipping live test");
+        return;
+    }
+    let client = ApiClient::new().unwrap();
+    let create_req = amp_rs::model::CreateAssetGroup {
+        name: "test_group".to_string(),
+    };
+    let create_res = client.create_asset_group(&create_req).await.unwrap();
+    assert_eq!(create_res.name, "test_group");
+
+    let delete_res = client.delete_asset_group(create_res.id).await;
+    assert!(delete_res.is_ok());
+}
+
+#[tokio::test]
+async fn test_get_and_update_asset_group_live() {
+    if env::var("AMP_TESTS").unwrap_or_default() != "live" {
+        println!("Skipping live test");
+        return;
+    }
+    let client = ApiClient::new().unwrap();
+    let create_req = amp_rs::model::CreateAssetGroup {
+        name: "test_group_2".to_string(),
+    };
+    let create_res = client.create_asset_group(&create_req).await.unwrap();
+
+    let get_res = client.get_asset_group(create_res.id).await.unwrap();
+    assert_eq!(get_res.name, "test_group_2");
+
+    let update_req = amp_rs::model::UpdateAssetGroup {
+        name: "test_group_2_updated".to_string(),
+    };
+    let update_res = client.update_asset_group(create_res.id, &update_req).await.unwrap();
+    assert_eq!(update_res.name, "test_group_2_updated");
+
+    let delete_res = client.delete_asset_group(create_res.id).await;
+    assert!(delete_res.is_ok());
+}
+
+#[tokio::test]
+async fn test_list_asset_groups_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_list_asset_groups(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let result = client.list_asset_groups().await;
+    assert!(result.is_ok());
+    assert!(!result.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn test_create_asset_group_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_create_asset_group(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let create_req = amp_rs::model::CreateAssetGroup {
+        name: "test_group".to_string(),
+    };
+    let result = client.create_asset_group(&create_req).await;
+    assert!(result.is_ok());
+    let group = result.unwrap();
+    assert_eq!(group.name, "test_group");
+}
+
+#[tokio::test]
+async fn test_get_asset_group_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_get_asset_group(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let result = client.get_asset_group(1).await;
+    assert!(result.is_ok());
+    let group = result.unwrap();
+    assert_eq!(group.id, 1);
+}
+
+#[tokio::test]
+async fn test_update_asset_group_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_update_asset_group(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let update_req = amp_rs::model::UpdateAssetGroup {
+        name: "updated_group_name".to_string(),
+    };
+    let result = client.update_asset_group(1, &update_req).await;
+    assert!(result.is_ok());
+    let group = result.unwrap();
+    assert_eq!(group.name, "updated_group_name");
+}
+
+#[tokio::test]
+async fn test_delete_asset_group_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_delete_asset_group(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let result = client.delete_asset_group(1).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_add_asset_to_group_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_add_asset_to_group(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let add_req = amp_rs::model::AddAssetToGroup {
+        asset_uuid: "mock_asset_uuid".to_string(),
+    };
+    let result = client.add_asset_to_group(1, &add_req).await;
+    assert!(result.is_ok());
+    let group = result.unwrap();
+    assert!(group.assets.contains(&"mock_asset_uuid".to_string()));
+}
+
+#[tokio::test]
+async fn test_remove_asset_from_group_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_remove_asset_from_group(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let result = client.remove_asset_from_group(1, "mock_asset_uuid").await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_list_asset_permissions_live() {
+    if env::var("AMP_TESTS").unwrap_or_default() != "live" {
+        println!("Skipping live test");
+        return;
+    }
+    let client = ApiClient::new().unwrap();
+    let result = client.list_asset_permissions().await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_create_and_delete_asset_permission_live() {
+    if env::var("AMP_TESTS").unwrap_or_default() != "live" {
+        println!("Skipping live test");
+        return;
+    }
+    let client = ApiClient::new().unwrap();
+    let managers = client.get_managers().await.unwrap();
+    let manager_id = managers.first().unwrap().id;
+    let assets = client.get_assets().await.unwrap();
+    let asset_uuid = assets.first().unwrap().asset_uuid.clone();
+
+    let create_req = amp_rs::model::CreateAssetPermission {
+        manager: manager_id,
+        asset: Some(asset_uuid),
+        asset_group: None,
+        permission: amp_rs::model::Permission::View,
+    };
+    let create_res = client.create_asset_permission(&create_req).await.unwrap();
+    assert_eq!(create_res.permission, amp_rs::model::Permission::View);
+
+    let delete_res = client.delete_asset_permission(create_res.id).await;
+    assert!(delete_res.is_ok());
+}
+
+#[tokio::test]
+async fn test_get_and_update_asset_permission_live() {
+    if env::var("AMP_TESTS").unwrap_or_default() != "live" {
+        println!("Skipping live test");
+        return;
+    }
+    let client = ApiClient::new().unwrap();
+    let managers = client.get_managers().await.unwrap();
+    let manager_id = managers.first().unwrap().id;
+    let assets = client.get_assets().await.unwrap();
+    let asset_uuid = assets.first().unwrap().asset_uuid.clone();
+
+    let create_req = amp_rs::model::CreateAssetPermission {
+        manager: manager_id,
+        asset: Some(asset_uuid.clone()),
+        asset_group: None,
+        permission: amp_rs::model::Permission::View,
+    };
+    let create_res = client.create_asset_permission(&create_req).await.unwrap();
+
+    let get_res = client.get_asset_permission(create_res.id).await.unwrap();
+    assert_eq!(get_res.permission, amp_rs::model::Permission::View);
+
+    let update_req = amp_rs::model::UpdateAssetPermission {
+        manager: manager_id,
+        asset: Some(asset_uuid),
+        asset_group: None,
+        permission: amp_rs::model::Permission::Transfer,
+    };
+    let update_res = client.update_asset_permission(create_res.id, &update_req).await.unwrap();
+    assert_eq!(update_res.permission, amp_rs::model::Permission::Transfer);
+
+    let delete_res = client.delete_asset_permission(create_res.id).await;
+    assert!(delete_res.is_ok());
+}
+
+#[tokio::test]
+async fn test_list_asset_permissions_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_list_asset_permissions(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let result = client.list_asset_permissions().await;
+    assert!(result.is_ok());
+    assert!(!result.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn test_create_asset_permission_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_create_asset_permission(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let create_req = amp_rs::model::CreateAssetPermission {
+        manager: 1,
+        asset: Some("mock_asset_uuid".to_string()),
+        asset_group: None,
+        permission: amp_rs::model::Permission::View,
+    };
+    let result = client.create_asset_permission(&create_req).await;
+    assert!(result.is_ok());
+    let permission = result.unwrap();
+    assert_eq!(permission.permission, amp_rs::model::Permission::View);
+}
+
+#[tokio::test]
+async fn test_get_asset_permission_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_get_asset_permission(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let result = client.get_asset_permission(1).await;
+    assert!(result.is_ok());
+    let permission = result.unwrap();
+    assert_eq!(permission.id, 1);
+}
+
+#[tokio::test]
+async fn test_update_asset_permission_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_update_asset_permission(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let update_req = amp_rs::model::UpdateAssetPermission {
+        manager: 1,
+        asset: Some("mock_asset_uuid".to_string()),
+        asset_group: None,
+        permission: amp_rs::model::Permission::Transfer,
+    };
+    let result = client.update_asset_permission(1, &update_req).await;
+    assert!(result.is_ok());
+    let permission = result.unwrap();
+    assert_eq!(permission.permission, amp_rs::model::Permission::Transfer);
+}
+
+#[tokio::test]
+async fn test_delete_asset_permission_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_delete_asset_permission(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let result = client.delete_asset_permission(1).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_broadcast_transaction_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_broadcast_transaction(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let result = client.broadcast_transaction("mock_tx_hex").await;
+    assert!(result.is_ok());
+    let res = result.unwrap();
+    assert_eq!(res.txid, "mock_txid");
+}
+
+#[tokio::test]
+async fn test_list_audits_live() {
+    if env::var("AMP_TESTS").unwrap_or_default() != "live" {
+        println!("Skipping live test");
+        return;
+    }
+    let client = ApiClient::new().unwrap();
+    let result = client.list_audits().await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_create_and_delete_audit_live() {
+    if env::var("AMP_TESTS").unwrap_or_default() != "live" {
+        println!("Skipping live test");
+        return;
+    }
+    let client = ApiClient::new().unwrap();
+    let assets = client.get_assets().await.unwrap();
+    let asset_uuid = assets.first().unwrap().asset_uuid.clone();
+
+    let create_req = amp_rs::model::CreateAudit {
+        asset_uuid,
+        audit_type: "test_audit".to_string(),
+    };
+    let create_res = client.create_audit(&create_req).await.unwrap();
+    assert_eq!(create_res.audit_type, "test_audit");
+
+    let delete_res = client.delete_audit(create_res.id).await;
+    assert!(delete_res.is_ok());
+}
+
+#[tokio::test]
+async fn test_get_and_update_audit_live() {
+    if env::var("AMP_TESTS").unwrap_or_default() != "live" {
+        println!("Skipping live test");
+        return;
+    }
+    let client = ApiClient::new().unwrap();
+    let assets = client.get_assets().await.unwrap();
+    let asset_uuid = assets.first().unwrap().asset_uuid.clone();
+
+    let create_req = amp_rs::model::CreateAudit {
+        asset_uuid,
+        audit_type: "test_audit_2".to_string(),
+    };
+    let create_res = client.create_audit(&create_req).await.unwrap();
+
+    let get_res = client.get_audit(create_res.id).await.unwrap();
+    assert_eq!(get_res.audit_type, "test_audit_2");
+
+    let update_req = amp_rs::model::UpdateAudit {
+        audit_status: "completed".to_string(),
+    };
+    let update_res = client.update_audit(create_res.id, &update_req).await.unwrap();
+    assert_eq!(update_res.audit_status, "completed");
+
+    let delete_res = client.delete_audit(create_res.id).await;
+    assert!(delete_res.is_ok());
+}
+
+#[tokio::test]
+async fn test_list_audits_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_list_audits(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let result = client.list_audits().await;
+    assert!(result.is_ok());
+    assert!(!result.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn test_create_audit_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_create_audit(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let create_req = amp_rs::model::CreateAudit {
+        asset_uuid: "mock_asset_uuid".to_string(),
+        audit_type: "test_audit".to_string(),
+    };
+    let result = client.create_audit(&create_req).await;
+    assert!(result.is_ok());
+    let audit = result.unwrap();
+    assert_eq!(audit.audit_type, "test_audit");
+}
+
+#[tokio::test]
+async fn test_get_audit_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_get_audit(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let result = client.get_audit(1).await;
+    assert!(result.is_ok());
+    let audit = result.unwrap();
+    assert_eq!(audit.id, 1);
+}
+
+#[tokio::test]
+async fn test_update_audit_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_update_audit(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let update_req = amp_rs::model::UpdateAudit {
+        audit_status: "completed".to_string(),
+    };
+    let result = client.update_audit(1, &update_req).await;
+    assert!(result.is_ok());
+    let audit = result.unwrap();
+    assert_eq!(audit.audit_status, "completed");
+}
+
+#[tokio::test]
+async fn test_delete_audit_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_delete_audit(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let result = client.delete_audit(1).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_get_broadcast_status_mock() {
+    std::env::set_var("AMP_USERNAME", "mock_user");
+    std::env::set_var("AMP_PASSWORD", "mock_pass");
+    let server = MockServer::start();
+    mocks::mock_obtain_token(&server);
+    mocks::mock_get_broadcast_status(&server);
+
+    let client = ApiClient::with_base_url(Url::parse(&server.base_url()).unwrap()).unwrap();
+    let result = client.get_broadcast_status("mock_txid").await;
+    assert!(result.is_ok());
+    let res = result.unwrap();
+    assert_eq!(res.txid, "mock_txid");
+}


### PR DESCRIPTION
This commit implements a significant portion of the Blockstream AMP API client, including endpoints for assets, asset groups, asset permissions, audits, transactions, categories, and users.

It also refactors the ApiClient to use generic request-handling functions, which reduces code duplication and improves maintainability.

Finally, it adds extensive tests (both live and mock) for all new functionality, and updates the README with better usage examples and testing instructions.